### PR TITLE
Added methods for styling the reader via the javascript api.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,11 @@
     android:name="org.librarysimplified.r2_sandbox.app.MainApplication"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/appName"
+    android:networkSecurityConfig="@xml/network_security_config"
     android:theme="@style/SandboxTheme"
-    tools:replace="android:label">
+    tools:ignore="GoogleAppIndexingWarning"
+    tools:replace="android:label"
+    tools:targetApi="n">
     <activity android:name="org.librarysimplified.r2_sandbox.app.MainActivity">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
@@ -21,5 +24,4 @@
       </intent-filter>
     </activity>
   </application>
-
 </manifest>

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPI.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPI.kt
@@ -2,6 +2,11 @@ package org.librarysimplified.r2_sandbox.app
 
 import android.webkit.WebView
 import androidx.annotation.UiThread
+import org.librarysimplified.r2_sandbox.app.ReaderTheme.DARK
+import org.librarysimplified.r2_sandbox.app.ReaderTheme.DAY
+import org.librarysimplified.r2_sandbox.app.ReaderTheme.LIGHT
+import org.librarysimplified.r2_sandbox.app.ReaderTheme.NIGHT
+import org.librarysimplified.r2_sandbox.app.ReaderTheme.SEPIA
 import org.slf4j.LoggerFactory
 
 /**
@@ -60,6 +65,20 @@ class ReaderJavascriptAPI(
 
   override fun setWordSpacing(value: Double) {
     setUserProperty("wordSpacing", "${value}rem")
+  }
+
+  override fun setTheme(value: ReaderTheme) {
+    when (value) {
+      LIGHT, DAY -> {
+        setUserProperty("appearance", "readium-default-on")
+      }
+      DARK, NIGHT -> {
+        setUserProperty("appearance", "readium-night-on")
+      }
+      SEPIA -> {
+        setUserProperty("appearance", "readium-sepia-on")
+      }
+    }
   }
 
   @UiThread

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPI.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPI.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.r2_sandbox.app
 
 import android.webkit.WebView
+import androidx.annotation.UiThread
 import org.slf4j.LoggerFactory
 
 /**
@@ -17,16 +18,40 @@ class ReaderJavascriptAPI(
   override fun scrollNext() {
     UIThread.checkIsUIThread()
 
-    this.webView.evaluateJavascript("scrollRight();") { value ->
-      this.logger.debug("evaluation result: {}", value)
+    this.webView.evaluateJavascript("scrollRight();") {
+      this.logger.debug("evaluation result: {}", it)
     }
   }
 
   override fun scrollPrevious() {
     UIThread.checkIsUIThread()
 
-    this.webView.evaluateJavascript("scrollLeft();") { value ->
-      this.logger.debug("evaluation result: {}", value)
+    this.webView.evaluateJavascript("scrollLeft();") {
+      this.logger.debug("evaluation result: {}", it)
+    }
+  }
+
+  override fun setFontFamily(value: String) {
+    setUserProperty("fontFamily", value)
+    setUserProperty("fontOverride", "readium-font-on")
+  }
+
+  override fun setTextSize(value: Int) {
+    // Note: The js property name is 'fontSize' not 'textSize'
+    setUserProperty("fontSize", "$value%")
+  }
+
+  override fun setTextAlign(value: String) {
+    setUserProperty("textAlign", value)
+  }
+
+  @UiThread
+  fun setUserProperty(name: String, value: String) {
+    UIThread.checkIsUIThread()
+
+    val script = "setProperty(\"--USER__${name}\", \"${value}\");"
+    this.webView.evaluateJavascript(script) {
+      this.logger.debug("evaluation result: {}", it)
     }
   }
 }

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPI.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPI.kt
@@ -38,11 +38,28 @@ class ReaderJavascriptAPI(
 
   override fun setTextSize(value: Int) {
     // Note: The js property name is 'fontSize' not 'textSize'
-    setUserProperty("fontSize", "$value%")
+    setUserProperty("fontSize", "${value}%")
   }
 
   override fun setTextAlign(value: String) {
     setUserProperty("textAlign", value)
+  }
+
+  override fun setPageMargin(value: Double) {
+    // Note: The js property name is 'pageMargins' plural
+    setUserProperty("pageMargins", "$value")
+  }
+
+  override fun setLineHeight(value: Double) {
+    setUserProperty("lineHeight", "$value")
+  }
+
+  override fun setLetterSpacing(value: Double) {
+    setUserProperty("letterSpacing", "${value}em")
+  }
+
+  override fun setWordSpacing(value: Double) {
+    setUserProperty("wordSpacing", "${value}rem")
   }
 
   @UiThread

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPIType.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPIType.kt
@@ -8,38 +8,34 @@ import androidx.annotation.UiThread
 
 interface ReaderJavascriptAPIType {
 
-  /**
-   * Scroll to the next page.
-   */
+  /** Scroll to the next page. */
 
   @UiThread
   fun scrollNext()
 
-  /**
-   * Scroll to the previous page.
-   */
+  /** Scroll to the previous page. */
 
   @UiThread
   fun scrollPrevious()
 
-  /**
-   * Set the font family.
-   */
-
   @UiThread
   fun setFontFamily(value: String)
-
-  /**
-   * Set the text size.
-   */
 
   @UiThread
   fun setTextSize(value: Int)
 
-  /**
-   * Set the text alignment.
-   */
-
   @UiThread
   fun setTextAlign(value: String)
+
+  @UiThread
+  fun setPageMargin(value: Double)
+
+  @UiThread
+  fun setLineHeight(value: Double)
+
+  @UiThread
+  fun setLetterSpacing(value: Double)
+
+  @UiThread
+  fun setWordSpacing(value: Double)
 }

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPIType.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPIType.kt
@@ -21,4 +21,25 @@ interface ReaderJavascriptAPIType {
 
   @UiThread
   fun scrollPrevious()
+
+  /**
+   * Set the font family.
+   */
+
+  @UiThread
+  fun setFontFamily(value: String)
+
+  /**
+   * Set the text size.
+   */
+
+  @UiThread
+  fun setTextSize(value: Int)
+
+  /**
+   * Set the text alignment.
+   */
+
+  @UiThread
+  fun setTextAlign(value: String)
 }

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPIType.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderJavascriptAPIType.kt
@@ -38,4 +38,7 @@ interface ReaderJavascriptAPIType {
 
   @UiThread
   fun setWordSpacing(value: Double)
+
+  @UiThread
+  fun setTheme(value: ReaderTheme)
 }

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderTheme.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderTheme.kt
@@ -1,0 +1,9 @@
+package org.librarysimplified.r2_sandbox.app
+
+enum class ReaderTheme {
+  LIGHT,
+  DARK,
+  DAY,
+  NIGHT,
+  SEPIA,
+}

--- a/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderViewerFragment.kt
+++ b/app/src/main/java/org/librarysimplified/r2_sandbox/app/ReaderViewerFragment.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.r2_sandbox.app
 
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -65,6 +66,12 @@ class ReaderViewerFragment : Fragment() {
     this.webView.webChromeClient = this.webChromeClient
     this.webView.isVerticalScrollBarEnabled = false
     this.webView.isHorizontalScrollBarEnabled = false
+
+    /*
+     * Enable WebView remote debugging.
+     */
+
+    WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
 
     /*
      * Disable manual scrolling on the web view. Scrolling is controlled via the javascript API.

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">127.0.0.1</domain>
+    <domain includeSubdomains="true">localhost</domain>
+  </domain-config>
+</network-security-config>


### PR DESCRIPTION
This is pretty bare-bones but I wanted to get theses changes in as a start.

I decided to keep the `ReaderJavascriptAPIType` interface mostly one-to-one with the javascript methods. My expectation being that these methods will be wrapped by some kind of `ReaderStyle` abstraction.

User styles are reset to the defaults when loading a new chapter into the webview. This means we'll have to persist all styles and periodically reapply them. We'll want to do this anyway, of course, so that styles persist across different books and reading sessions.

Next up is adding a basic user interface for these controls.